### PR TITLE
Fix missing parameter for red print label

### DIFF
--- a/inventree_brother/brother_plugin.py
+++ b/inventree_brother/brother_plugin.py
@@ -108,6 +108,12 @@ class BrotherLabelPlugin(LabelPrintingMixin, SettingsMixin, InvenTreePlugin):
         auto_cut = self.get_setting('AUTO_CUT')
         rotation = self.get_setting('ROTATION')
 
+        # Check if red labels used
+        if label in ['62red']:
+            red = True
+        else:
+            red = False
+
         printer = BrotherQLRaster(model=model)
 
         # Generate instructions for printing
@@ -118,6 +124,7 @@ class BrotherLabelPlugin(LabelPrintingMixin, SettingsMixin, InvenTreePlugin):
             'rotate': rotation,
             'hq': True,
             'label': label,
+            'red': red,
         }
 
         if model in ['PT-P750W', 'PT-P900W']:


### PR DESCRIPTION
When using label '62red', the flag --red must be supplied, otherwise an error 'wrong roll type' appears on the printer.

See https://github.com/pklaus/brother_ql/issues/52

This fixes that issue, by automatically adding the --red flag if the red label is used.