### PR TITLE
Point to fork of brother-ql lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.vscode/
 
 # Spyder project settings
 .spyderproject

--- a/README.md
+++ b/README.md
@@ -10,18 +10,16 @@ This plugin supports printing to *some* Brother label printers with network (wir
 
 ## Installation
 
-> :warning: Installation via pypi (e.g. `pip install inventree-brother-plugin`) currently does not work!
-
-Instead, install this plugin as follows:
+Install this plugin manually as follows:
 
 ```
-pip install git+https://github.com/inventree/inventree-brother-plugin
+pip install inventree-brother-plugin
 ```
 
-Or, add to your `plugins.txt` file:
+Or, add to your `plugins.txt` file to install automatically using the `invoke install` command:
 
 ```
- git+https://github.com/inventree/inventree-brother-plugin
+inventree-brother-plugin
 ```
  
 ## Configuration Options

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
 
     install_requires=[
-        'brother_ql @ git+https://github.com/pklaus/brother_ql/@56cf4394ad750346c6b664821ccd7489ec140dae',
+        'brother-ql-inventree',
     ],
 
     setup_requires=[
@@ -40,7 +40,7 @@ setuptools.setup(
         "twine",
     ],
 
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 
     entry_points={
         "inventree_plugins": [


### PR DESCRIPTION
We now have our [own fork](https://github.com/matmair/brother_ql-inventree) of [brother-ql] which is more up to date, and thus can now to installs via pypi!