### PR TITLE
Add printing options framework

### DIFF
--- a/inventree_brother/brother_plugin.py
+++ b/inventree_brother/brother_plugin.py
@@ -56,13 +56,6 @@ class BrotherLabelSerializer(serializers.Serializer):
     Used to specify printing parameters at runtime
     """
 
-    class Meta:
-        """Meta options for this serializer"""
-
-        fields = [
-            'copies',
-        ]
-    
     copies = serializers.IntegerField(
         default=1,
         label=_('Copies'),
@@ -148,7 +141,7 @@ class BrotherLabelPlugin(LabelPrintingMixin, SettingsMixin, InvenTreePlugin):
         # Printing options requires a modern-ish InvenTree backend,
         # which supports the 'printing_options' keyword argument
         options = kwargs.get('printing_options', {})
-        n_copies = min(1, options.get('copies', 1))
+        n_copies = int(options.get('copies', 1))
 
         # Look for png data in kwargs (if provided)
         label_image = kwargs.get('png_file', None)

--- a/inventree_brother/version.py
+++ b/inventree_brother/version.py
@@ -1,3 +1,3 @@
 """Version information for the plugin"""
 
-BROTHER_PLUGIN_VERSION = "0.7.2"
+BROTHER_PLUGIN_VERSION = "0.8.0"


### PR DESCRIPTION
- Ref: https://github.com/inventree/InvenTree/pull/5786
- Ref: https://github.com/inventree/inventree-brother-plugin/issues/30

For now, this only adds in a "number of copies" option. But, other options could be added too. For example if multiple printers are available on the network, select which one to use