### PR TITLE
USB printer support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,30 @@ pip install pdf-info python-poppler
 ```
 
 ## Configuration Options
+The following list gives an overview of the available settings. Also check out the `brother-ql` package for more information.
 
-**TODO**
+* **Printer Model**
+Currently supported models are: 
+QL-500, QL-550, QL-560, QL-570, QL-580N, QL-600, QL-650TD, QL-700, QL-710W, QL-720NW, QL-800, QL-810W, QL-820NWB, QL-1050, QL-1060N, QL-1100, QL-1100NWB, QL-1115NWB, PT-P750W, PT-P900W, PT-P950NW
+
+* **Label Media**
+Size and type of the label media. Supported options are (not all labels are available on all printers): 
+12, 18, 29, 38, 50, 54, 62, 62red, 102, 103, 104, 17x54, 17x87, 23x23, 29x42, 29x90, 39x90, 39x48, 52x29, 54x29, 60x86, 62x29, 62x100, 102x51, 102x152, 103x164, d12, d24, d58, pt12, pt18, pt24, pt36
+
+* **IP Address**
+If connected via TCP/IP, specify the IP address here.
+
+* **USB Device**
+If connected via USB, specify the device identifier here (VENDOR_ID:PRODUCT_ID/SERIAL_NUMBER, e.g. from `lsusb`).
+
+* **Auto Cut**
+Cut label after printing.
+
+* **Rotation**
+Rotation angle, either 0, 90, 180 or 270 degrees.
+
+* **Compression**
+Set image compression (required for some printers).
+
+* **High Quality**
+Print in high quality (required for some printers).

--- a/inventree_brother/brother_plugin.py
+++ b/inventree_brother/brother_plugin.py
@@ -98,7 +98,7 @@ class BrotherLabelPlugin(LabelPrintingMixin, SettingsMixin, InvenTreePlugin):
         },
         'USB_DEVICE': {
             'name': _('USB Device'),
-            'description': _('USB device identifier of the label printer (<VID>:<PID>/<SERIAL>)'),
+            'description': _('USB device identifier of the label printer (VID:PID/SERIAL)'),
             'default': '',
         },
         'AUTO_CUT': {

--- a/inventree_brother/brother_plugin.py
+++ b/inventree_brother/brother_plugin.py
@@ -219,10 +219,10 @@ class BrotherLabelPlugin(LabelPrintingMixin, SettingsMixin, InvenTreePlugin):
 
         # check IP address first, then USB
         if ip_address:
-            printer_id=f'tcp://{ip_address}'
+            printer_id = f'tcp://{ip_address}'
             backend_id = 'network'
         elif usb_device:
-            printer_id=f'usb://{usb_device}'
+            printer_id = f'usb://{usb_device}'
             backend_id = 'pyusb'
         else:
             # Raise error when no backend is defined

--- a/inventree_brother/version.py
+++ b/inventree_brother/version.py
@@ -1,3 +1,3 @@
 """Version information for the plugin"""
 
-BROTHER_PLUGIN_VERSION = "0.8.2"
+BROTHER_PLUGIN_VERSION = "0.8.3"


### PR DESCRIPTION
Added an additional configuration item for printers connected through USB. If both, IP and USB settings are defined, the IP setting is preferred.
Also extended the README with available configuration options.

resolves inventree/inventree-brother-plugin#29